### PR TITLE
support ceph disk

### DIFF
--- a/deploy/mod/deploy.py
+++ b/deploy/mod/deploy.py
@@ -223,7 +223,7 @@ class Deploy(object):
         else:
             clean_build = False
 
-        map_diff = self.cal_cephmap_diff()
+        map_diff = self.cal_cephmap_diff(ceph_disk=ceph_disk)
         common.printout("WARNING","Found different configuration from conf/ceph_current_conf with your desired config : %s" % map_diff)
         self.map_diff = map_diff
         cephconf = []
@@ -350,7 +350,7 @@ class Deploy(object):
         if request_type == "plain":
             return ceph_daemon_lines
 
-    def cal_cephmap_diff(self):
+    def cal_cephmap_diff(self, ceph_disk=False):
         old_conf = self.read_cephconf()
 
         cephconf_dict = OrderedDict()
@@ -365,6 +365,9 @@ class Deploy(object):
                 cephconf_dict[osd] = self.cluster[osd]
             else:
                 for device in self.cluster[osd]:
+                    if ceph_disk:
+                        data, journal = device.split(":")
+                        device = data + "1" + ":" + journal + "1"
                     if device not in old_conf["osd"][osd]:
                         if osd not in cephconf_dict["osd"]:
                             cephconf_dict["osd"][osd] = self.cluster["osds"][osd]
@@ -412,7 +415,7 @@ class Deploy(object):
             common.bash("cp -f ../conf/ceph.conf ../conf/ceph_current_status")
 
         else:
-            diff_map = self.cal_cephmap_diff()
+            diff_map = self.cal_cephmap_diff(ceph_disk=ceph_disk)
 
             if gen_cephconf:
                 self.gen_cephconf(ceph_disk=ceph_disk)

--- a/deploy/mod/deploy_rgw.py
+++ b/deploy/mod/deploy_rgw.py
@@ -300,9 +300,9 @@ class Deploy_RGW(Deploy) :
             common.pdsh(self.cluster['user'], [rgw], "sed -i 's/ENABLED=0/ENABLED=1/g' /etc/default/haproxy" )
             common.pdsh(self.cluster['user'], [rgw], "/etc/init.d/haproxy restart" )
 
-    def cal_cephmap_diff(self):
+    def cal_cephmap_diff(self, ceph_disk=False):
         old_conf = self.read_cephconf()
-        cephconf_dict = super(self.__class__, self).cal_cephmap_diff()
+        cephconf_dict = super(self.__class__, self).cal_cephmap_diff(ceph_disk=ceph_disk)
         cephconf_dict["radosgw"] = []
         for node in self.cluster["rgw"]:
             if node not in old_conf["radosgw"]:

--- a/deploy/mod/deploy_rgw.py
+++ b/deploy/mod/deploy_rgw.py
@@ -25,13 +25,13 @@ class Deploy_RGW(Deploy) :
         self.cluster["proxy"] = self.all_conf_data.get("cosbench_controller_proxy")
         self.cluster["auth_url"] = "http://%s/auth/v1.0;retry=9" % self.cluster["rgw"][0]
 
-    def redeploy(self, gen_cephconf ):
+    def redeploy(self, gen_cephconf, ceph_disk=False):
         self.map_diff = self.cal_cephmap_diff()
         rgw_nodes = self.map_diff["radosgw"]
-        super(self.__class__, self).redeploy(gen_cephconf)
+        super(self.__class__, self).redeploy(gen_cephconf, ceph_disk=False)
         self.rgw_dependency_install()
         self.rgw_install()
-        self.gen_cephconf()
+        self.gen_cephconf(ceph_disk=ceph_disk)
         self.distribute_conf()
         #self.restart()
 
@@ -105,8 +105,8 @@ class Deploy_RGW(Deploy) :
         for node in self.cluster["rgw"]:
             common.scp(self.cluster["user"], node, "../conf/ceph.conf", "/etc/ceph")
 
-    def gen_cephconf(self):
-        super(self.__class__, self).gen_cephconf()
+    def gen_cephconf(self, option="refresh", ceph_disk=False):
+        super(self.__class__, self).gen_cephconf(ceph_disk=ceph_disk)
         if self.cluster["clean_build"] == "true":
             clean_build = True
         else:

--- a/deploy/run_deploy.py
+++ b/deploy/run_deploy.py
@@ -34,6 +34,12 @@ def main(args):
         default = False,
         action='store_true'
         )
+    parser.add_argument(
+        '--ceph_disk',
+        default=False,
+        action='store_true'
+    )
+
     args = parser.parse_args(args)
     if args.operation == "caldiff":
         mydeploy = deploy.Deploy()
@@ -44,7 +50,8 @@ def main(args):
         if args.with_rgw:
             mydeploy = deploy_rgw.Deploy_RGW()
 #            mydeploy.deploy()
-        mydeploy.redeploy(args.gen_cephconf)
+        mydeploy.redeploy(args.gen_cephconf,
+                          ceph_disk=args.ceph_disk)
 
     if args.operation == "restart":
         mydeploy = deploy.Deploy()
@@ -73,7 +80,7 @@ def main(args):
             mydeploy = deploy_rgw.Deploy_RGW(tuning)
         else:
             mydeploy = deploy.Deploy(tuning)
-        mydeploy.gen_cephconf()
+        mydeploy.gen_cephconf(args.ceph_disk)
     if args.operation == "install_binary":
         mydeploy = deploy.Deploy()
         mydeploy.install_binary(args.version)

--- a/deploy/run_deploy.py
+++ b/deploy/run_deploy.py
@@ -55,8 +55,7 @@ def main(args):
 
     if args.operation == "restart":
         mydeploy = deploy.Deploy()
-        mydeploy.cleanup()
-        mydeploy.startup(ceph_disk=args.ceph_disk)
+        mydeploy.restart(ceph_disk=args.ceph_disk)
         if args.with_rgw:
             mydeploy = deploy_rgw.Deploy_RGW()
             mydeploy.restart_rgw()
@@ -65,7 +64,7 @@ def main(args):
         mydeploy.startup(ceph_disk=args.ceph_disk)
     if args.operation == "shutdown":
         mydeploy = deploy.Deploy()
-        mydeploy.cleanup()
+        mydeploy.cleanup(ceph_disk=args.ceph_disk)
     if args.operation == "distribute_conf":
         if args.with_rgw:
             mydeploy = deploy_rgw.Deploy_RGW()

--- a/deploy/run_deploy.py
+++ b/deploy/run_deploy.py
@@ -43,7 +43,7 @@ def main(args):
     args = parser.parse_args(args)
     if args.operation == "caldiff":
         mydeploy = deploy.Deploy()
-        mydeploy.cal_cephmap_diff()
+        mydeploy.cal_cephmap_diff(ceph_disk=args.ceph_disk)
 
     if args.operation == "redeploy":
         mydeploy = deploy.Deploy()
@@ -80,7 +80,7 @@ def main(args):
             mydeploy = deploy_rgw.Deploy_RGW(tuning)
         else:
             mydeploy = deploy.Deploy(tuning)
-        mydeploy.gen_cephconf(args.ceph_disk)
+        mydeploy.gen_cephconf(ceph_disk=args.ceph_disk)
     if args.operation == "install_binary":
         mydeploy = deploy.Deploy()
         mydeploy.install_binary(args.version)

--- a/deploy/run_deploy.py
+++ b/deploy/run_deploy.py
@@ -56,13 +56,13 @@ def main(args):
     if args.operation == "restart":
         mydeploy = deploy.Deploy()
         mydeploy.cleanup()
-        mydeploy.startup()
+        mydeploy.startup(ceph_disk=args.ceph_disk)
         if args.with_rgw:
             mydeploy = deploy_rgw.Deploy_RGW()
             mydeploy.restart_rgw()
     if args.operation == "startup":
         mydeploy = deploy.Deploy()
-        mydeploy.startup()
+        mydeploy.startup(ceph_disk=args.ceph_disk)
     if args.operation == "shutdown":
         mydeploy = deploy.Deploy()
         mydeploy.cleanup()


### PR DESCRIPTION
1. Three default parameters of ceph-disk can be changed under the ../conf/all.conf. You can add them in all.conf like others. If they are not in the all.conf, the default value will be used.
#============ceph_disk_config============
prepend_to_path=/usr/bin
statedir=/var/lib/ceph
sysconfdir=/etc/ceph
2. The osd data path is statedir + "/osd/ceph-$id"
3. The data:journal should use whole block devices, not a partition.
4. You can run "python run_deploy.py redeploy --gen_cephconf --ceph_disk" to use ceph-disk