### PR TITLE
benchmarking: fix zipf enabling in qemurbd test

### DIFF
--- a/benchmarking/mod/bblock/fiorbd.py
+++ b/benchmarking/mod/bblock/fiorbd.py
@@ -176,11 +176,12 @@ class FioRbd(Benchmark):
         if io_pattern in ["randread", "randwrite", "randrw"]:
             fio_template.append("    iodepth_batch_submit=1")
             fio_template.append("    iodepth_batch_complete=1")
+            fio_template.append("    norandommap")
+            fio_template.append("    randrepeat=0")
+            fio_template.append("    userspace_reap")
             if fio_capping != "false":
                 fio_template.append("    rate_iops=100")
             if enable_zipf != "false":
-                #fio_zipf_tmp = int(fio_zipf)
-                fio_template.append("    norandommap")
                 fio_template.append("    random_distribution=%s" % (fio_zipf))
         if io_pattern in ["seqread", "seqwrite", "readwrite", "rw"]:
             fio_template.append("    iodepth_batch_submit=8")

--- a/benchmarking/mod/bblock/qemurbd.py
+++ b/benchmarking/mod/bblock/qemurbd.py
@@ -289,11 +289,12 @@ class QemuRbd(Benchmark):
         if io_pattern in ["randread", "randwrite", "randrw"]:
             fio_template.append("    iodepth_batch_submit=1")
             fio_template.append("    iodepth_batch_complete=1")
+            fio_template.append("    norandommap")
+            fio_template.append("    ranrepeat=0")
+            fio_template.append("    userspace_reap")
             if fio_capping != "false":
                 fio_template.append("    rate_iops=100")
-            if fio_zipf != "false":
-                #fio_zipf_tmp = int(fio_zipf)
-                fio_template.append("    norandommap")
+            if enable_zipf != "false":
                 fio_template.append("    random_distribution=%s" % (fio_zipf))
         if io_pattern in ["seqread", "seqwrite", "readwrite", "rw"]:
             fio_template.append("    iodepth_batch_submit=8")


### PR DESCRIPTION
adding several fio options for a true/high performance random tests:

norandommap
randrepeat=0
userspace_reap

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>