### PR TITLE
Added one option to turn on/off randrepeat

### DIFF
--- a/benchmarking/mod/bblock/fiorbd.py
+++ b/benchmarking/mod/bblock/fiorbd.py
@@ -177,7 +177,8 @@ class FioRbd(Benchmark):
             fio_template.append("    iodepth_batch_submit=1")
             fio_template.append("    iodepth_batch_complete=1")
             fio_template.append("    norandommap")
-            fio_template.append("    randrepeat=0")
+            if fio_randrepeat == "false":
+                fio_template.append("    randrepeat=0")
             fio_template.append("    userspace_reap")
             if fio_capping != "false":
                 fio_template.append("    rate_iops=100")

--- a/benchmarking/mod/bblock/qemurbd.py
+++ b/benchmarking/mod/bblock/qemurbd.py
@@ -290,7 +290,8 @@ class QemuRbd(Benchmark):
             fio_template.append("    iodepth_batch_submit=1")
             fio_template.append("    iodepth_batch_complete=1")
             fio_template.append("    norandommap")
-            fio_template.append("    ranrepeat=0")
+            if fio_randrepeat == "false":
+                fio_template.append("    randrepeat=0")
             fio_template.append("    userspace_reap")
             if fio_capping != "false":
                 fio_template.append("    rate_iops=100")

--- a/conf/handler.py
+++ b/conf/handler.py
@@ -64,12 +64,16 @@ class ConfigHandler():
             if engine == "qemurbd":
                 required["list_vclient"] = "vclient01,vclient02..."
                 required["fio_capping"] = "false"
+                required["enable_zipf"] = "false"
+                required["fio_randrepeat"] = "false"
                 required["volume_size"] = "40960"
                 required["rbd_volume_count"] = "1"
                 required["disk_num_per_client"] = "35,35,35,35"
                 required["rwmixread"] = 100
             if engine == "fiorbd":
                 required["fio_capping"] = "false"
+                required["enable_zipf"] = "false"
+                required["fio_randrepeat"] = "false"
                 required["volume_size"] = "40960"
                 required["rbd_volume_count"] = "1"
                 required["disk_num_per_client"] = "35,35,35,35"


### PR DESCRIPTION
Also added an automatically show up of option
enable_zipf and fio_randrepeat when using fiorbd or qemurbd as workload

Signed-off-by: xuechendi <chendi.xue@intel.com>