### PR TITLE
Separate head with cetune installed node

### DIFF
--- a/analyzer/analyzer.py
+++ b/analyzer/analyzer.py
@@ -219,17 +219,17 @@ class Analyzer:
                 tmp_data["IOPS"] = "%.3f" % read_IOPS
                 tmp_data["BW(MB/s)"] = "%.3f" % read_BW
                 if rbd_count > 0:
-                    tmp_data["Latency(ms)"] = "%.3f" % read_Latency/rbd_count
+                    tmp_data["Latency(ms)"] = "%.3f" % (read_Latency/rbd_count)
             elif tmp_data["Op_Type"] in ["randwrite", "seqwrite", "write"]:
                 tmp_data["IOPS"] = "%.3f" % write_IOPS
                 tmp_data["BW(MB/s)"] = "%.3f" % write_BW
                 if rbd_count > 0:
-                    tmp_data["Latency(ms)"] = "%.3f" % write_Latency/rbd_count
+                    tmp_data["Latency(ms)"] = "%.3f" % (write_Latency/rbd_count)
             elif tmp_data["Op_Type"] in ["randrw", "rw", "readwrite"]:
                 tmp_data["IOPS"] = "%.3f, %.3f" % (read_IOPS, write_IOPS)
                 tmp_data["BW(MB/s)"] = "%.3f, %.3f" % (read_BW, write_BW)
                 if rbd_count > 0:
-                    tmp_data["Latency(ms)"] = "%.3f, %.3f" % (read_Latency/rbd_count, write_Latency/rbd_count)
+                    tmp_data["Latency(ms)"] = "%.3f, %.3f" % ((read_Latency/rbd_count), (write_Latency/rbd_count))
         except:
             pass
         read_SN_IOPS = 0

--- a/benchmarking/mod/bblock/fiorbd.py
+++ b/benchmarking/mod/bblock/fiorbd.py
@@ -227,8 +227,8 @@ class FioRbd(Benchmark):
         dest_dir = self.cluster["dest_dir"]
         #collect client data
         for node in self.benchmark["distribution"].keys():
-            common.pdsh(user, [head], "mkdir -p %s/raw/%s" % (dest_dir, node))
+            common.bash("mkdir -p %s/raw/%s" % (dest_dir, node))
             common.rscp(user, node, "%s/raw/%s/" % (dest_dir, node), "%s/*.log" % self.cluster["tmp_dir"])
-        common.rscp(user, head, "%s/conf/" % dest_dir, "%s/conf/fio.conf" % self.pwd)
-        common.rscp(user, head, "%s/conf/" % dest_dir, "/etc/ceph/ceph.conf")
+        common.cp("%s/conf/fio.conf" % self.pwd, "%s/conf/" % dest_dir)
+        common.cp("/etc/ceph/ceph.conf", "%s/conf/" % dest_dir)
         common.bash("mkdir -p %s/conf/fio_errorlog/;find %s/raw/ -name '*_fio_errorlog.txt' | while read file; do cp $file %s/conf/fio_errorlog/;done" % (dest_dir, dest_dir, dest_dir))

--- a/benchmarking/mod/bblock/qemurbd.py
+++ b/benchmarking/mod/bblock/qemurbd.py
@@ -246,10 +246,10 @@ class QemuRbd(Benchmark):
         for client in self.benchmark["distribution"]:
             nodes = self.benchmark["distribution"][client]
             for node in nodes:
-                common.pdsh(user, [head], "mkdir -p %s/raw/%s" % (dest_dir, node))
+                common.bash("mkdir -p %s/raw/%s" % (dest_dir, node))
                 common.rscp(user, node, "%s/raw/%s/" % (dest_dir, node), "%s/*.txt" % self.cluster["tmp_dir"])
-        common.rscp(user, head, "%s/conf/" % dest_dir, "%s/conf/fio.conf" % self.pwd)
-        common.rscp(user, head, "%s/conf/" % dest_dir, "/etc/ceph/ceph.conf")
+        common.cp("%s/conf/fio.conf" % self.pwd, "%s/conf/" % dest_dir )
+        common.cp("/etc/ceph/ceph.conf", "%s/conf/" % dest_dir)
         common.bash("mkdir -p %s/conf/fio_errorlog/;find %s/raw/ -name '*_fio_errorlog.txt' | while read file; do cp $file %s/conf/fio_errorlog/;done" % (dest_dir, dest_dir, dest_dir))
 
     def generate_benchmark_cases(self, testcase):

--- a/benchmarking/mod/benchmark.py
+++ b/benchmarking/mod/benchmark.py
@@ -224,10 +224,10 @@ class Benchmark(object):
         dest_dir = self.cluster["dest_dir"]
         #collect all.conf
         try:
-            common.pdsh(user, [head], "mkdir -p %s/conf" % (dest_dir))
-            common.rscp(user, head, "%s/conf" % (dest_dir), "%s/conf/all.conf" % self.pwd)
-            common.rscp(user, head, "%s/conf" % (dest_dir), "%s/conf/%s" % (self.pwd, common.cetune_log_file) )
-            common.rscp(user, head, "%s/conf" % (dest_dir), "%s/conf/%s" % (self.pwd, common.cetune_error_file) )
+            common.bash("mkdir -p %s/conf" % (dest_dir))
+            common.cp("%s/conf/all.conf" % self.pwd, "%s/conf/" % dest_dir)
+            common.cp("%s/conf/%s" % (self.pwd, common.cetune_log_file), "%s/conf/" % dest_dir)
+            common.cp("%s/conf/%s" % (self.pwd, common.cetune_error_file), "%s/conf/" % dest_dir)
             common.bash("rm -f %s/conf/%s" % (self.pwd, common.cetune_log_file))
             common.bash("rm -f %s/conf/%s" % (self.pwd, common.cetune_error_file))
         except:
@@ -237,13 +237,13 @@ class Benchmark(object):
         if self.benchmark["tuning_section"] in worksheet:
             common.write_yaml_file( "%s/conf/tuner.yaml" % dest_dir, {self.benchmark["tuning_section"]:worksheet[self.benchmark["tuning_section"]]})
         else:
-            common.rscp(user, head, "%s/conf/tuner.yaml" % (dest_dir), "%s/conf/tuner.yaml" % (self.pwd) )
+            common.cp("%s/conf/tuner.yaml" % (dest_dir), "%s/conf/tuner.yaml" % (self.pwd) )
         #write description to dir
         with open( "%s/conf/description" % dest_dir, 'w+' ) as f:
             f.write( self.benchmark["description"] )
         #collect osd data
         for node in self.cluster["osd"]:
-            common.pdsh(user, [head], "mkdir -p %s/raw/%s" % (dest_dir, node))
+            common.bash("mkdir -p %s/raw/%s" % (dest_dir, node))
             common.rscp(user, node, "%s/raw/%s/" % (dest_dir, node), "%s/*.txt" % self.cluster["tmp_dir"])
             if "blktrace" in self.cluster["collector"]:
                 common.rscp(user, node, "%s/raw/%s/" % (dest_dir, node), "%s/*blktrace*" % self.cluster["tmp_dir"])
@@ -252,7 +252,7 @@ class Benchmark(object):
 
         #collect client data
         for node in self.benchmark["distribution"].keys():
-            common.pdsh(user, [head], "mkdir -p %s/raw/%s" % (dest_dir, node))
+            common.bash( "mkdir -p %s/raw/%s" % (dest_dir, node))
             common.rscp(user, node, "%s/raw/%s/" % (dest_dir, node), "%s/*.txt" % self.cluster["tmp_dir"])
 
         #save real runtime
@@ -414,8 +414,8 @@ class Benchmark(object):
         user = self.cluster["user"]
         head = self.cluster["head"]
         dest_dir = self.cluster["dest_dir"]
-        common.pdsh(user, [head], "mkdir -p %s/conf" % (dest_dir))
-        common.pdsh(user, [head], "echo %s > %s/conf/status" % (status, dest_dir))
+        common.bash("mkdir -p %s/conf" % (dest_dir))
+        common.bash("echo %s > %s/conf/status" % (status, dest_dir))
 
     def prepare_result_dir(self):
         res = common.pdsh(self.cluster["user"],["%s"%(self.cluster["head"])],"test -d %s" % (self.cluster["dest_dir"]), option = "check_return")

--- a/benchmarking/mod/bobject/cosbench.py
+++ b/benchmarking/mod/bobject/cosbench.py
@@ -394,7 +394,7 @@ class Cosbench(Benchmark):
         ceph_nodes = []
         ceph_nodes.extend(self.rgw["rgw_server"])
         for node in ceph_nodes:
-            common.pdsh(user, [head], "mkdir -p %s/raw/%s" % (dest_dir, node))
+            common.bash("mkdir -p %s/raw/%s" % (dest_dir, node))
             common.rscp(user, node, "%s/raw/%s/" % (dest_dir, node), "%s/*.txt" % self.cluster["tmp_dir"])
 
         cosbench_controller = self.cosbench["cosbench_controller"]

--- a/conf/common.py
+++ b/conf/common.py
@@ -230,6 +230,16 @@ def bash(command, force=False, option="", nodie=False):
             sys.exit()
     return stdout
 
+def cp(localfile, remotefile):
+    args = ['cp', '-r', localfile, remotefile]
+    printout("CONSOLE", args, screen=False)
+    #print('scp: %s' % args)
+    stdout, stderr = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True).communicate()
+    printout("CONSOLE", stdout, screen=False)
+    if stderr:
+        print('scp: %s' % args)
+        printout("WARNING",stderr+"\n")
+
 def scp(user, node, localfile, remotefile):
     args = ['scp', '-oConnectTimeout=15', '-r',localfile, '%s@%s:%s' % (user, node, remotefile)]
     printout("CONSOLE", args, screen=False)


### PR DESCRIPTION
    cetune installed node need to be able to ssh cetune controller and cetune node, and restore data at cetune installed node
    head need to be able to check ceph health.

Signed-off-by: Chendi.Xue <chendi.xue@intel.com>