### PR TITLE
gprep for fio need add '-x' for precise matching

### DIFF
--- a/benchmarking/init_rbd.sh
+++ b/benchmarking/init_rbd.sh
@@ -54,7 +54,7 @@ if [ "`check_fio_rbd`" = "true" ]; then
         sleep(5)
         for client in $clients
         do
-            res=`ssh $client pgrep fio`
+            res=`ssh $client pgrep -x fio`
             if [ ! -z $res ]; then
                 continue
             fi
@@ -83,7 +83,7 @@ else
             sleep(5)
             for vclient in $nodes
             do
-                res=`ssh $vclient pgrep fio`
+                res=`ssh $vclient pgrep -x fio`
                 if [ ! -z $res ]; then
                     continue
                 fi

--- a/benchmarking/mod/bblock/fiorbd.py
+++ b/benchmarking/mod/bblock/fiorbd.py
@@ -124,7 +124,7 @@ class FioRbd(Benchmark):
         while not stop_flag:
             stop_flag = 1
             nodes = self.benchmark["distribution"].keys()
-            res = common.pdsh(user, nodes, "pgrep fio", option = "check_return")
+            res = common.pdsh(user, nodes, "pgrep -x fio", option = "check_return")
             if res and not res[1]:
                 stop_flag = 0
                 common.printout("WARNING","FIO stills run on %s" % str(res[0].split('\n')))

--- a/benchmarking/mod/bcephfs/fiocephfs.py
+++ b/benchmarking/mod/bcephfs/fiocephfs.py
@@ -44,7 +44,7 @@ class FioCephFS(Benchmark):
 	    max_instance_num = self.benchmark["distribution"][client][-1]
             res = common.pdsh(user, [client], "for job_num in `seq 0 %d`; do %s/fio --output %s/`hostname`_${job_num}_fio.txt --write_bw_log=%s/`hostname`_${job_num}_fio --write_lat_log=%s/`hostname`_${job_num}_fio --write_iops_log=%s/`hostname`_${job_num}_fio --section %s --filename=`hostname`.${job_num} %s/fio.conf 2>%s/`hostname`_${job_num}_fio_errorlog.txt & done" % (max_instance_num, fio_dir, dest_dir, dest_dir, dest_dir, dest_dir, self.benchmark["section_name"], dest_dir, dest_dir, ), option = "force")         
             time.sleep(1)
-            res = common.pdsh(user, [client], "pgrep fio", option = "check_return")
+            res = common.pdsh(user, [client], "pgrep -x fio", option = "check_return")
             if res and not len(res[0].split('\n')) >= len(self.benchmark["distribution"][client]):
                 common.printout("ERROR","Failed to start FIO process")
                 raise KeyboardInterrupt
@@ -67,7 +67,7 @@ class FioCephFS(Benchmark):
         while not stop_flag:
             stop_flag = 1
             nodes = self.benchmark["distribution"].keys()
-            res = common.pdsh(user, nodes, "pgrep fio", option = "check_return")
+            res = common.pdsh(user, nodes, "pgrep -x fio", option = "check_return")
             if res and not res[1]:
                 stop_flag = 0
                 common.printout("WARNING","FIO stills run on %s" % str(res[0].split('\n')))

--- a/benchmarking/mod/benchmark.py
+++ b/benchmarking/mod/benchmark.py
@@ -343,7 +343,7 @@ class Benchmark(object):
 
     def check_fio_pgrep(self, nodes, fio_node_num = 1, check_type="jobnum"):
         user =  self.cluster["user"]
-        stdout, stderr = common.pdsh(user, nodes, "pgrep fio", option = "check_return")
+        stdout, stderr = common.pdsh(user, nodes, "pgrep -x fio", option = "check_return")
         res = common.format_pdsh_return(stdout)
         if res != []:
             fio_running_job_num = 0

--- a/benchmarking/mod/generic/generic.py
+++ b/benchmarking/mod/generic/generic.py
@@ -129,7 +129,7 @@ class Generic(Benchmark):
         while not stop_flag:
             stop_flag = 1
             nodes = self.benchmark["distribution"].keys()
-            res = common.pdsh(user, nodes, "pgrep fio", option = "check_return")
+            res = common.pdsh(user, nodes, "pgrep -x fio", option = "check_return")
             if res and not res[1]:
                 stop_flag = 0
                 common.printout("WARNING","FIO stills run on %s" % str(res[0].split('\n')))


### PR DESCRIPTION
In my cluster, running CeTune and then using `pgrep fio`, you can see: 
`[root@opencos247 ~]# pgrep  -l fio`
`4180 dm_bufio_cache
6700 fio
6853 fio
6854 fio
6855 fio
6856 fio
6857 fio`

a process  ID for `dm_bufio_cache` will add to the list of `stdout`  `res`, so wo should rm it. And if using `gprep -x fio` can avoid it, like:
`[root@opencos247 ~]# pgrep -x -l fio`
`6700 fio
6853 fio
6854 fio
6855 fio
6856 fio
6857 fio`
Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>