### PR TITLE
'sync' need before 'drop_caches'

### DIFF
--- a/benchmarking/mod/benchmark.py
+++ b/benchmarking/mod/benchmark.py
@@ -151,7 +151,7 @@ class Benchmark(object):
         nodes = self.cluster["osd"]
         monitor_interval = self.cluster["monitoring_interval"]
         #nodes.extend(self.benchmark["distribution"].keys())
-        common.pdsh(user, nodes, "echo '%s' > /proc/sys/vm/drop_caches && sync" % self.cluster["cache_drop_level"])
+        common.pdsh(user, nodes, "sync && echo '%s' > /proc/sys/vm/drop_caches" % self.cluster["cache_drop_level"])
 
         #send command to ceph cluster
         common.pdsh(user, nodes, "for i in `seq 1 %d`;do echo `date \"+%s\"` `ceph health` >> %s/`hostname`_ceph_health.txt; sleep %s;done" % (time_tmp/int(monitor_interval)+1, "%Y_%m_%d %H:%M:%S", dest_dir, monitor_interval), option="force")


### PR DESCRIPTION

drop_caches

Writing to this will cause the kernel to drop clean caches, as well as
reclaimable slab objects like dentries and inodes.  Once dropped, their
memory becomes free.

To free pagecache:
	echo 1 > /proc/sys/vm/drop_caches
To free reclaimable slab objects (includes dentries and inodes):
	echo 2 > /proc/sys/vm/drop_caches
To free slab objects and pagecache:
	echo 3 > /proc/sys/vm/drop_caches

This is a non-destructive operation and will not free any dirty objects.
To increase the number of objects freed by this operation, the user may run
`sync' prior to writing to /proc/sys/vm/drop_caches.  This will minimize the
number of dirty objects on the system and create more candidates to be
dropped.

And you can see  [https://www.kernel.org/doc/Documentation/sysctl/vm.txt](url)

Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>