### PR TITLE
optimization web loading speed,del no use interactive

### DIFF
--- a/conf/description.py
+++ b/conf/description.py
@@ -27,7 +27,7 @@ class Description(object):
 	if key in Description.read_conf_to_dict().keys():
             return Description.read_conf_to_dict()[key]
         else:
-            print "the key is not exists."
+            #print "the key is not exists."
             return ""
 
 class DefaultValue(object):

--- a/webui/static/js/Script.js
+++ b/webui/static/js/Script.js
@@ -345,7 +345,7 @@ $(document).ready(function(){
             case "menu_Configuration_id":
                 clearTimer(timer_Console);
                 clearTimer(timer_Report);
-                RunStatus_Timer();
+                //RunStatus_Timer();
                 timer_RunStatus = setInterval(RunStatus_Timer,interval_RunStatus);
                break;
             
@@ -432,9 +432,9 @@ $(document).ready(function(){
 	
     
     //traverse the sub menu li, check Configuation Data is true----------------------------------
-    CheckTableDataError();
+    //CheckTableDataError();
 	
-    ExecutvieCheckSync();
+    //ExecutvieCheckSync();
 	
     //Executive 
     if(CheckIsExecutive() == "true"){    
@@ -584,7 +584,7 @@ function Init(){
 	 
 	
     //(4)decide server is runing,start the timer;
-    RunStatus_Timer();
+    //RunStatus_Timer();
     timer_RunStatus = setInterval(RunStatus_Timer,interval_RunStatus);
 	
 }
@@ -641,9 +641,13 @@ function DisplayConfiguationDataTable(request_type){
     //(1) get data for json obj
     var jsonObj_Config = GetConfigurationData(request_type);
 
-    var address_Benchmark = "../configuration/get_group?request_type=testcase";
-    var jsonObj_Benchmark = GetDataByAjax(address_Benchmark);    
-    console.log("jsonObj_Bnechmark");
+    var jsonObj_Benchmark;
+    if(request_type == "benchmark"){
+	    var address_Benchmark = "../configuration/get_group?request_type=testcase";
+	    jsonObj_Benchmark = GetDataByAjax(address_Benchmark);    
+	    //var jsonObj_Benchmark = GetDataByAjax(address_Benchmark);    
+	    console.log("jsonObj_Bnechmark");
+    }
     //(2) display table
     CreateDataTableForConfiguration(jsonObj_Config , jsonObj_Benchmark ,request_type);
     console.log("CreateDataTableForConfiguration");

--- a/webui/templates/index.html
+++ b/webui/templates/index.html
@@ -53,7 +53,10 @@
        <h1><a href="#">CeTune -- Ceph tuning and profiling</a></h1>
     </div>
      <div id="div_top_status_id">
+     <!--
        <h1>Benchmark is runing.....</h1>
+	-->
+       <h1>CeTune Status: idle Ceph Status: None</h1>
        <h6 class='ceph_thr'></h6>
       <!-- <h1><a href="#"><img id="img_top_id" src="image/progruss.jpg" />Benchmark is runing.....</a></h1>-->
     </div>


### PR DESCRIPTION
1.del "load all conf"
    The web load all of conf file when it's init,
    But click menu，It load agent,so I del "init load"
2.del "load testcase conf"
    Nomater what menu I click,the web will load testcase,but it's no needed.
3.del "get ceph health"
    Getting the ceph health will take a long time,It's no need to do when web init.
    It has a timer and It will done after web init.
    