### PR TITLE
Description is Null in generic scenario

### DIFF
--- a/benchmarking/mod/generic/generic.py
+++ b/benchmarking/mod/generic/generic.py
@@ -205,7 +205,7 @@ class Generic(Benchmark):
             "block_size":p[3], "qd":p[4], "rampup":p[5], 
             "runtime":p[6], "vdisk":p[7]
         }
-        if len(p) == 9:
+        if len(p) >= 9:
             testcase_dict["description"] = p[8]
         else:
             testcase_dict["description"] = ""

--- a/benchmarking/mod/generic/generic.py
+++ b/benchmarking/mod/generic/generic.py
@@ -205,8 +205,8 @@ class Generic(Benchmark):
             "block_size":p[3], "qd":p[4], "rampup":p[5], 
             "runtime":p[6], "vdisk":p[7]
         }
-        if len(p) >= 9:
-            testcase_dict["description"] = p[8]
+        if len(p) >= 10:
+            testcase_dict["description"] = p[9]
         else:
             testcase_dict["description"] = ""
         return testcase_dict


### PR DESCRIPTION
When length of test cases is bigger than 9, the description is null.
This is fixed in this patch.

Signed-off-by: Lisa Li <xiaoyan.li@intel.com>