### PR TITLE
[generic]delete the cluster["run_time_extend"]

### DIFF
--- a/benchmarking/mod/generic/generic.py
+++ b/benchmarking/mod/generic/generic.py
@@ -71,7 +71,7 @@ class Generic(Benchmark):
 
         #drop page cache
         user = self.cluster["user"]
-        waittime = int(self.benchmark["runtime"]) + int(self.benchmark["rampup"]) + self.cluster["run_time_extend"]
+        waittime = int(self.benchmark["runtime"]) + int(self.benchmark["rampup"])
         dest_dir = self.cluster["tmp_dir"]
         nodes = self.cluster["osd"]
         nodes.extend(self.benchmark["distribution"].keys())


### PR DESCRIPTION
the self.cluster["run_time_extend"] is useless in here.
But the test run secs will add it(100 sec)
e.g.
[LOG]: This test will run "runtime + rampup + self.cluster["run_time_extend"] " secs until finish.