### PR TITLE
analyzer/visualizer: show 95.00% and 99.99% lat data

### DIFF
--- a/analyzer/analyzer.py
+++ b/analyzer/analyzer.py
@@ -398,7 +398,9 @@ class Analyzer:
         tmp_data["IOPS"] = 0
         tmp_data["BW(MB/s)"] = 0
         tmp_data["Latency(ms)"] = 0
+        tmp_data["95.00th%_lat(ms)"] = 0
         tmp_data["99.00th%_lat(ms)"] = 0
+        tmp_data["99.99th%_lat(ms)"] = 0
         tmp_data["SN_IOPS"] = 0
         tmp_data["SN_BW(MB/s)"] = 0
         tmp_data["SN_Latency(ms)"] = 0
@@ -412,6 +414,8 @@ class Analyzer:
             write_BW = 0
             write_Latency = 0
             max_lat = 0
+            max_lat_95 = 0
+            max_lat_99 = 0
             for engine_candidate in data["workload"].keys():
                 if engine_candidate in benchmark_tool:
                     engine = engine_candidate
@@ -423,7 +427,9 @@ class Analyzer:
                 write_IOPS += float(node_data["write_iops"])
                 write_BW += float(node_data["write_bw"])
                 write_Latency += float(node_data["write_lat"])
-                max_lat += float(node_data["99.00th%_lat"])
+                max_lat_95 += float(node_data["95.00th%_lat"])
+                max_lat_99 += float(node_data["99.00th%_lat"])
+                max_lat += float(node_data["99.99th%_lat"])
             if tmp_data["Op_Type"] in ["randread", "seqread", "read"]:
                 tmp_data["IOPS"] = "%.3f" % read_IOPS
                 tmp_data["BW(MB/s)"] = "%.3f" % read_BW
@@ -440,7 +446,9 @@ class Analyzer:
                 if rbd_count > 0:
                     tmp_data["Latency(ms)"] = "%.3f, %.3f" % ((read_Latency/rbd_count), (write_Latency/rbd_count))
             if rbd_count > 0:
-                tmp_data["99.00th%_lat(ms)"] = "%.3f" % (max_lat/rbd_count)
+                tmp_data["95.00th%_lat(ms)"] = "%.3f" % (max_lat_95/rbd_count)
+                tmp_data["99.00th%_lat(ms)"] = "%.3f" % (max_lat_99/rbd_count)
+                tmp_data["99.99th%_lat(ms)"] = "%.3f" % (max_lat/rbd_count)
         except:
             pass
         read_SN_IOPS = 0

--- a/visualizer/create_DB.py
+++ b/visualizer/create_DB.py
@@ -25,7 +25,9 @@ class database(object):
                 iops float not null,
                 bw float not null,
                 latency float not null,
+                latency_95 float not null,
                 latency_99 float not null,
+                latency_9999 float not null,
                 sniops float not null,
                 snbw float not null,
                 snlatency float not null
@@ -74,13 +76,12 @@ class database(object):
             rowdata[2] =='None'
         if rowdata[4] == '':
             rowdata[4] = 'None'
-        if len(rowdata) == 19:
-            sqlstr = "insert into tb_report (runid,runid_tr,timestamp,status,description,opsize,optype,qd,driver,snnumber,cnnumber,worker,runtime,iops,bw,latency,latency_99,sniops,snbw,snlatency) values ("+rowdata[1]+",'"+rowdata[0]+"','"+rowdata[2]+"','"+rowdata[3]+"','"+rowdata[4]+"','"+rowdata[5]+"','"+rowdata[6]+"','"+rowdata[7]+"','"+rowdata[8]+"',"+rowdata[9]+","+rowdata[10]+","+rowdata[11]+","+rowdata[12]+",'"+rowdata[13]+"','"+rowdata[14]+"','"+rowdata[15]+"','0.00','"+rowdata[16]+"','"+rowdata[17]+"','"+rowdata[18]+"')"
-        else:
-            sqlstr = "insert into tb_report (runid,runid_tr,timestamp,status,description,opsize,optype,qd,driver,snnumber,cnnumber,worker,runtime,iops,bw,latency,latency_99,sniops,snbw,snlatency) values ("+rowdata[1]+",'"+rowdata[0]+"','"+rowdata[2]+"','"+rowdata[3]+"','"+rowdata[4]+"','"+rowdata[5]+"','"+rowdata[6]+"','"+rowdata[7]+"','"+rowdata[8]+"',"+rowdata[9]+","+rowdata[10]+","+rowdata[11]+","+rowdata[12]+",'"+rowdata[13]+"','"+rowdata[14]+"','"+rowdata[15]+"','"+rowdata[16]+"','"+rowdata[17]+"','"+rowdata[18]+"','"+rowdata[19]+"')"
-
-        #sqlstr = "insert into tb_report (runid,runid_tr,utatus,description,opsize,optype,qd,driver,snnumber,cnnumber,worker,runtime,iops,bw,latency,sniops,snbw,snlatency) values (%d,'%s','%s','%s','%s','%s','%s','%s',%d,%d,%d,%d,%f,%f,%f,%f,%f,%f)"%(rowdata[1],rowdata[0],rowdata[2],rowdata[3],rowdata[4],rowdata[5],rowdata[6],rowdata[7],rowdata[8],rowdata[9],rowdata[10],rowdata[11],rowdata[12],rowdata[13],rowdata[14],rowdata[15],rowdata[16],rowdata[17])
-        print sqlstr
+        if len(rowdata) == 22:
+            sqlstr = "insert into tb_report (runid,runid_tr,timestamp,status,description,opsize,optype,qd,driver,snnumber,cnnumber,worker,runtime,iops,bw,latency,latency_95,latency_99,latency_9999,sniops,snbw,snlatency) values ("+rowdata[1]+",'"+rowdata[0]+"','"+rowdata[2]+"','"+rowdata[3]+"','"+rowdata[4]+"','"+rowdata[5]+"','"+rowdata[6]+"','"+rowdata[7]+"','"+rowdata[8]+"',"+rowdata[9]+","+rowdata[10]+","+rowdata[11]+","+rowdata[12]+",'"+rowdata[13]+"','"+rowdata[14]+"','"+rowdata[15]+"','"+rowdata[16]+"','"+rowdata[17]+"','"+rowdata[18]+"','"+rowdata[19]+"','"+rowdata[20]+"','"+rowdata[21]+"')"
+        elif len(rowdata) == 20:
+            sqlstr = "insert into tb_report (runid,runid_tr,timestamp,status,description,opsize,optype,qd,driver,snnumber,cnnumber,worker,runtime,iops,bw,latency,latency_95,latency_99,latency_9999,sniops,snbw,snlatency) values ("+rowdata[1]+",'"+rowdata[0]+"','"+rowdata[2]+"','"+rowdata[3]+"','"+rowdata[4]+"','"+rowdata[5]+"','"+rowdata[6]+"','"+rowdata[7]+"','"+rowdata[8]+"',"+rowdata[9]+","+rowdata[10]+","+rowdata[11]+","+rowdata[12]+",'"+rowdata[13]+"','"+rowdata[14]+"','"+rowdata[15]+"','0.00','"+rowdata[16]+"','0.00','"+rowdata[17]+"','"+rowdata[18]+"','"+rowdata[19]+"')"
+        elif len(rowdata) == 19:
+            sqlstr = "insert into tb_report (runid,runid_tr,timestamp,status,description,opsize,optype,qd,driver,snnumber,cnnumber,worker,runtime,iops,bw,latency,latency_95,latency_99,latency_9999,sniops,snbw,snlatency) values ("+rowdata[1]+",'"+rowdata[0]+"','"+rowdata[2]+"','"+rowdata[3]+"','"+rowdata[4]+"','"+rowdata[5]+"','"+rowdata[6]+"','"+rowdata[7]+"','"+rowdata[8]+"',"+rowdata[9]+","+rowdata[10]+","+rowdata[11]+","+rowdata[12]+",'"+rowdata[13]+"','"+rowdata[14]+"','"+rowdata[15]+"','0.00','0.00','0.00','"+rowdata[16]+"','"+rowdata[17]+"','"+rowdata[18]+"')"
         conn.execute(sqlstr)
         conn.commit()
         print "Add data to TB successfully."

--- a/visualizer/visualizer.py
+++ b/visualizer/visualizer.py
@@ -303,10 +303,12 @@ class Visualizer:
         output.append(" <th data-resizable-column-id='13'><a title='Benchmarked IOPS' id='runid_fio_iops' href='#'>IOPS</a></th>")
         output.append(" <th data-resizable-column-id='14'><a title='Benchmarked Bandwidth' id='runid_fio_bw' href='#'>BW(MB/s)</a></th>")
         output.append(" <th data-resizable-column-id='15'><a title='Benchmarked Latency' id='runid_fio_latency' href='#'>Latency(ms)</a></th>")
-        output.append(" <th data-resizable-column-id='16'><a title='Benchmarked Latency 99.00' id='runid_fio_latency_99' href='#'>99.00% Latency(ms)</a></th>")
-        output.append(" <th data-resizable-column-id='17'><a title='Storage Node IOPS' id='runid_osd_iops' href='#'>SN_IOPS</a></th>")
-        output.append(" <th data-resizable-column-id='18'><a title='Storage Node Bandwidth' id='runid_osd_bw' href='#'>SN_BW(MB/s)</a></th>")
-        output.append(" <th data-resizable-column-id='19'><a title='Storage Node Latency' id='runid_osd_latency' href='#'>SN_Latency(ms)</a></th>")
+        output.append(" <th data-resizable-column-id='16'><a title='Benchmarked Latency 95.00' id='runid_fio_latency_95' href='#'>95.00% Latency(ms)</a></th>")
+        output.append(" <th data-resizable-column-id='17'><a title='Benchmarked Latency 99.00' id='runid_fio_latency_99' href='#'>99.00% Latency(ms)</a></th>")
+        output.append(" <th data-resizable-column-id='18'><a title='Benchmarked Latency 99.99' id='runid_fio_latency_9999' href='#'>99.99% Latency(ms)</a></th>")
+        output.append(" <th data-resizable-column-id='19'><a title='Storage Node IOPS' id='runid_osd_iops' href='#'>SN_IOPS</a></th>")
+        output.append(" <th data-resizable-column-id='20'><a title='Storage Node Bandwidth' id='runid_osd_bw' href='#'>SN_BW(MB/s)</a></th>")
+        output.append(" <th data-resizable-column-id='21'><a title='Storage Node Latency' id='runid_osd_latency' href='#'>SN_Latency(ms)</a></th>")
         output.append(" </tr>")
         return output
 


### PR DESCRIPTION
Currently we have 99.00% latency data only in reults summary page.
It might better to show 95.00% and 99.99% latency data also as these
data are also valuable for tail latency study.

This patch does the calculation the 95.00% and 99.99% data and alow
these data to be displayed on the summary page. Also we modified the
index page to display avg latency and 95.00% 99.00% and 99.99% latency data.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>
Signed-off-by: Chendi.Xue <chendi.xue@intel.com>